### PR TITLE
Add backtest endpoint and timeframe selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@
    uvicorn backend.app:app --reload
    ```
 3. فتح المتصفح على `http://localhost:8000` لعرض الواجهة وتجربة واجهة البرمجة.
+
+### نقاط نهاية إضافية
+
+- `GET /api/watchlist` : استرجاع قائمة المتابعة الحالية.
+- `POST /api/watchlist/{symbol}` : إضافة رمز إلى قائمة المتابعة.
+- `DELETE /api/watchlist/{symbol}` : إزالة رمز من قائمة المتابعة.
+- `GET /api/risk-profile` : معرفة ملف المخاطر الحالي.
+- `POST /api/risk-profile/{profile}` : تعيين ملف المخاطر (`conservative`، `moderate`، `aggressive`).
+- `GET /api/recommendation/{symbol}?tf=15m` : استرجاع توصية لرمز مع التحقق من الإطار الزمني (`15m`، `1h`، `1d`).
+- `POST /api/backtest` : إرسال JSON يحتوي على `symbol` و`tf` لإرجاع نتيجة Backtest مبسطة.
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,24 +1,163 @@
-from fastapi import FastAPI
+"""Simple backend providing placeholder trading features.
+
+This module exposes a small subset of the endpoints described in the
+initial design document.  The goal is to provide a working skeleton that
+front-end developers can build upon.  Data is stored in memory which means
+it will reset whenever the application restarts.  It is **not** meant for
+production use but gives an idea of how the API might look.
+"""
+
+from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
 
 app = FastAPI(title="AI Stock Bot")
 
+
+# ---------------------------------------------------------------------------
+# In-memory storage used for the demo.  A real implementation would store
+# this data in a persistent database with proper authentication.
+# ---------------------------------------------------------------------------
+watchlist: list[str] = []
+risk_profile: str = "moderate"
+# Allowed timeframes for demo validation
+ALLOWED_TFS = {"15m", "1h", "1d"}
+
+
+class BacktestRequest(BaseModel):
+    """Incoming payload for the backtest endpoint."""
+
+    symbol: str
+    tf: str = "1d"
+
+
+class BacktestResult(BaseModel):
+    """Simplified backtest result."""
+
+    symbol: str
+    timeframe: str
+    trades: int
+    pnl: float
+    sharpe: float
+
+
 @app.get("/api/recommendation/{symbol}")
-async def recommendation(symbol: str):
-    """Return a placeholder recommendation for a stock symbol."""
+async def recommendation(symbol: str, tf: str = "15m"):
+    """Return a placeholder recommendation for a stock symbol.
+
+    Parameters
+    ----------
+    symbol: str
+        The ticker symbol requested by the client.
+    tf: str
+        Timeframe for the recommendation, default ``"15m"``.
+    """
+
+    if tf not in ALLOWED_TFS:
+        raise HTTPException(status_code=400, detail="Invalid timeframe")
+
+    entry = 100.0
+    stop_loss = 95.0
+    take_profit = [110.0, 120.0]
+    rr_ratio = round((take_profit[0] - entry) / (entry - stop_loss), 2)
+
     return {
         "symbol": symbol.upper(),
-        "action": "buy",
-        "confidence": 0.75,
-        "entry": 100.0,
-        "stop": 95.0,
-        "targets": [110.0, 120.0],
-        "rationale": ["breakout", "volume spike"]
+        "timeframe": tf,
+        "direction": "long",
+        "entry": entry,
+        "stop_loss": stop_loss,
+        "take_profit": take_profit,
+        "prob_up": 0.62,
+        "rr_ratio": rr_ratio,
+        "confidence": "medium",
+        "reasoning": [
+            "اختراق مقاومة بفوليوم أعلى من المتوسط",
+            "RSI يرتفع",
+            "غياب أحداث سلبية قريبة",
+        ],
+        "indicators": {"atr14": 0.28, "rsi14": 56.3, "ema20": 33.22},
+        "risk_checks": {"liquidity_ok": True, "event_risk_next_24h": "none"},
+        "risk_profile": risk_profile,
     }
+
+
+@app.get("/api/watchlist")
+async def get_watchlist():
+    """Return the current watchlist."""
+
+    return {"symbols": watchlist}
+
+
+@app.post("/api/watchlist/{symbol}")
+async def add_to_watchlist(symbol: str):
+    """Add a symbol to the watchlist."""
+
+    symbol = symbol.upper()
+    if symbol not in watchlist:
+        watchlist.append(symbol)
+    return {"symbols": watchlist}
+
+
+@app.delete("/api/watchlist/{symbol}")
+async def remove_from_watchlist(symbol: str):
+    """Remove a symbol from the watchlist."""
+
+    symbol = symbol.upper()
+    try:
+        watchlist.remove(symbol)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Symbol not in watchlist")
+    return {"symbols": watchlist}
+
+
+@app.get("/api/risk-profile")
+async def get_risk_profile():
+    """Return the current risk profile."""
+
+    return {"risk_profile": risk_profile}
+
+
+@app.post("/api/risk-profile/{profile}")
+async def set_risk_profile(profile: str):
+    """Set the risk profile to one of the allowed values."""
+
+    profile = profile.lower()
+    allowed = {"conservative", "moderate", "aggressive"}
+    if profile not in allowed:
+        raise HTTPException(status_code=400, detail="Invalid profile")
+
+    global risk_profile
+    risk_profile = profile
+    return {"risk_profile": risk_profile}
+
+
+@app.post("/api/backtest", response_model=BacktestResult)
+async def backtest(req: BacktestRequest):
+    """Return a dummy backtest result for a symbol and timeframe."""
+
+    if req.tf not in ALLOWED_TFS:
+        raise HTTPException(status_code=400, detail="Invalid timeframe")
+
+    # Placeholder metrics representing a very naive strategy
+    result = BacktestResult(
+        symbol=req.symbol.upper(),
+        timeframe=req.tf,
+        trades=10,
+        pnl=5.2,
+        sharpe=1.3,
+    )
+    return result
+
 
 app.mount("/static", StaticFiles(directory="frontend"), name="static")
 
+
 @app.get("/")
 async def index():
+    """Serve the front-end HTML file."""
+
     return FileResponse("frontend/index.html")
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,9 +7,46 @@
 </head>
 <body>
   <h1>AI Stock Bot</h1>
-  <input id="symbol" type="text" placeholder="Enter symbol" />
-  <button onclick="fetchRecommendation()">Get Recommendation</button>
+  <section>
+    <input id="symbol" type="text" placeholder="Enter symbol" />
+    <select id="timeframe">
+      <option value="15m">15m</option>
+      <option value="1h">1h</option>
+      <option value="1d">1d</option>
+    </select>
+    <button onclick="fetchRecommendation()">Get Recommendation</button>
+  </section>
+
+  <section>
+    <h2>Watchlist</h2>
+    <input id="watch-symbol" type="text" placeholder="Add symbol" />
+    <button onclick="addToWatchlist()">Add</button>
+    <ul id="watchlist"></ul>
+  </section>
+
+  <section>
+    <h2>Risk Profile</h2>
+    <select id="risk-profile" onchange="updateRiskProfile()">
+      <option value="conservative">Conservative</option>
+      <option value="moderate" selected>Moderate</option>
+      <option value="aggressive">Aggressive</option>
+    </select>
+  </section>
+
+  <section>
+    <h2>Backtest</h2>
+    <input id="bt-symbol" type="text" placeholder="Symbol" />
+    <select id="bt-timeframe">
+      <option value="15m">15m</option>
+      <option value="1h">1h</option>
+      <option value="1d" selected>1d</option>
+    </select>
+    <button onclick="runBacktest()">Run</button>
+    <pre id="backtest-result"></pre>
+  </section>
+
   <pre id="result"></pre>
   <script src="/static/script.js"></script>
 </body>
 </html>
+

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,7 +1,108 @@
-async function fetchRecommendation() {
-  const symbol = document.getElementById('symbol').value;
+async function fetchRecommendation(symbolInput) {
+  const symbol =
+    typeof symbolInput === 'string'
+      ? symbolInput
+      : document.getElementById('symbol').value.trim();
   if (!symbol) return;
-  const response = await fetch(`/api/recommendation/${symbol}`);
-  const data = await response.json();
-  document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+  const tf = document.getElementById('timeframe').value;
+  try {
+    const response = await fetch(`/api/recommendation/${symbol}?tf=${tf}`);
+    if (!response.ok) throw new Error('failed to fetch recommendation');
+    const data = await response.json();
+    document.getElementById('result').textContent = JSON.stringify(
+      data,
+      null,
+      2,
+    );
+  } catch (err) {
+    document.getElementById('result').textContent = err.message;
+  }
 }
+
+async function loadWatchlist() {
+  try {
+    const res = await fetch('/api/watchlist');
+    if (!res.ok) throw new Error('failed to load watchlist');
+    const data = await res.json();
+    const list = document.getElementById('watchlist');
+    list.innerHTML = '';
+    data.symbols.forEach((sym) => {
+      const li = document.createElement('li');
+      li.textContent = sym;
+      li.style.cursor = 'pointer';
+      li.onclick = () => fetchRecommendation(sym);
+      const del = document.createElement('button');
+      del.textContent = 'x';
+      del.style.marginLeft = '0.5rem';
+      del.onclick = async (e) => {
+        e.stopPropagation();
+        await fetch(`/api/watchlist/${sym}`, { method: 'DELETE' });
+        loadWatchlist();
+      };
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  } catch (err) {
+    document.getElementById('result').textContent = err.message;
+  }
+}
+
+async function addToWatchlist() {
+  const input = document.getElementById('watch-symbol');
+  const symbol = input.value.trim().toUpperCase();
+  if (!symbol) return;
+  try {
+    await fetch(`/api/watchlist/${symbol}`, { method: 'POST' });
+    input.value = '';
+    loadWatchlist();
+  } catch (err) {
+    document.getElementById('result').textContent = err.message;
+  }
+}
+
+async function updateRiskProfile() {
+  const profile = document.getElementById('risk-profile').value;
+  try {
+    await fetch(`/api/risk-profile/${profile}`, { method: 'POST' });
+  } catch (err) {
+    document.getElementById('result').textContent = err.message;
+  }
+}
+
+async function runBacktest() {
+  const symbol = document.getElementById('bt-symbol').value.trim();
+  const tf = document.getElementById('bt-timeframe').value;
+  if (!symbol) return;
+  try {
+    const res = await fetch('/api/backtest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ symbol, tf }),
+    });
+    if (!res.ok) throw new Error('failed to backtest');
+    const data = await res.json();
+    document.getElementById('backtest-result').textContent = JSON.stringify(
+      data,
+      null,
+      2,
+    );
+  } catch (err) {
+    document.getElementById('backtest-result').textContent = err.message;
+  }
+}
+
+async function init() {
+  try {
+    // Load initial state
+    const res = await fetch('/api/risk-profile');
+    if (!res.ok) throw new Error('failed to fetch risk profile');
+    const data = await res.json();
+    document.getElementById('risk-profile').value = data.risk_profile;
+    loadWatchlist();
+  } catch (err) {
+    document.getElementById('result').textContent = err.message;
+  }
+}
+
+window.onload = init;
+

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2,3 +2,9 @@ body {
   font-family: Arial, sans-serif;
   margin: 2rem;
 }
+
+#watchlist li {
+  list-style: none;
+  margin: 0.25rem 0;
+}
+


### PR DESCRIPTION
## Summary
- add placeholder backtest API with pydantic request/response models
- support timeframe selection on frontend when requesting recommendations
- expose simple backtest form in UI and document new endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f984e2418832cba9dbb24e474f524